### PR TITLE
refactor(handleClientRequest): simplify request-response handling

### DIFF
--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -66,4 +66,6 @@ class Config
 };
 
 std::ostream &operator<<(std::ostream &os, const Config &obj);
-const LocationConfig *matchLocation(const std::string &path, ServerConfig &obj);
+const LocationConfig *matchLocation(const std::string &path, const ServerConfig &obj);
+std::string buildRequestAndResponse(const std::string& raw, const ServerConfig& srv, Request& outReq);
+void applyLocationConfig(Request& reqObj, const LocationConfig& loc);


### PR DESCRIPTION
This PR refactors the request-response pipeline inside `handleClientRequest()` to make the code cleaner and more maintainable.  

Changes include:  
- Added `buildRequestAndResponse()` to parse the raw input and build the request and response objects.  
- Added `applyLocationConfig()` to handle location-specific request configuration.  

No behavior changes were made; this is purely a code structure improvement.
