### PR TITLE
Fix/tests eval sheet

### DIFF
--- a/config/one-server.conf
+++ b/config/one-server.conf
@@ -11,7 +11,8 @@ server             {
         root /var/www/site1;
         index index.htm a index.html;
         autoindex off;
-        allow_upload off;
+        upload_path var/www/site1/uploads;
+        #allow_upload off;
     }
 
     location /images {

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -19,11 +19,11 @@ static const char *MIME_HTML = "text/html";
 
 Response::Response() : fullPath_(".") {}
 
-Response::Response(std::map<int, std::string> error_pages) :
-    fullPath_("."), error_pages_config(error_pages) {}
+Response::Response(std::map<int, std::string> error_pages)
+    : statusCode_(200), fullPath_("."), error_pages_config(error_pages) {}
 
 Response::Response(std::map<int, std::string> error_pages, int code, const std::string &message, bool error)
-    : fullPath_("."), error_pages_config(error_pages)
+    : statusCode_(200), fullPath_("."), error_pages_config(error_pages)
 {
     setPage(code, message, error);
 }

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -383,10 +383,20 @@ std::string Response::buildResponse(const Request &reqObj, const LocationConfig 
         return (this->writeResponseString());
     }
 
-    if (!locConfig.isMethodAllowed(reqObj.getMethod()) && reqObj.getMethod() != "POST") {
+    if (!locConfig.isMethodAllowed(reqObj.getMethod())) {
         this->setPage(405, "Method not allowed", true);
-        this->setHeader("Allow", "GET, POST, DELETE");
+        std::vector<std::string> allowed = locConfig.getAllowedMethods();
+        std::string allowHeader;
+        for (size_t i = 0; i < allowed.size(); i++)
+        {
+            allowHeader += allowed[i];
+            if (i != allowed.size() - 1)
+                allowHeader += ", ";
+        }
+        this->setHeader("Allow", allowHeader);
+        return (this->writeResponseString());
     }
+
     else if (reqObj.isCgi()) {
         this->handleCgi(reqObj, locConfig);
     } else if (!reqObj.getMethod().compare("GET")) {

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -242,7 +242,7 @@ void Response::handleDelete(const Request &reqObj) {
         setPage(500, "Failed to delete file: \"" + filename_ + "\"", true);
         return;
     }
-    setPage(200, "File \"" + filename_ + "\" deleted successfully.", true);
+    setPage(204, "No content. File \"" + filename_ + "\" deleted successfully.", true);
 }
 
 void Response::parseMultipartBody(const Request &obj) {

--- a/test_webserv.sh
+++ b/test_webserv.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Webserver Test Script (compatible with bash 3.x)
 # Usage: ./test_webserv.sh [host] [port]
-# Example: ./test_webserv.sh 127.0.0.1 8080
+# Example: ./test_webserv.sh 127.0.0.1 9080
 
 HOST=${1:-127.0.0.1}
-PORT=${2:-8080}
+PORT=${2:-9080}
 BASE_URL="http://$HOST:$PORT"
 
 # Colors
@@ -20,8 +20,8 @@ FAIL_COUNT=0
 get_allowed_methods() {
     local location="$1"
     case "$location" in
-        "/") echo "GET" ;;
-        "/upload") echo "GET POST" ;;       # DELETE not allowed
+        "/") echo "GET DELETE" ;;
+        "/upload") echo "GET POST DELETE" ;;       # DELETE not allowed
         "/images") echo "GET POST DELETE" ;;
         "/redirect-me") echo "GET" ;;
         "/cgi-bin") echo "GET POST" ;;
@@ -100,7 +100,7 @@ fi
 # DELETE /upload/file
 CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE $BASE_URL/upload/upload_test.txt)
 EXPECTED=$(get_expected /upload DELETE)
-print_result $CODE $EXPECTED "DELETE /upload/upload_test.txt"
+print_result $CODE 204 "DELETE /upload/upload_test.txt"
 
 # --------------------
 # UNKNOWN method
@@ -125,6 +125,29 @@ EXPECTED=$(get_expected /redirect-me GET)
 print_result $CODE $EXPECTED "GET /redirect-me (redirect)"
 
 # --------------------
+
+# DELETE non-existing file
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE $BASE_URL/upload/doesnotexist.txt)
+print_result $CODE 404 "DELETE /upload/doesnotexist.txt (non-existing file)"
+
+# --------------------
+# Upload & GET file (content match)
+echo "hello upload world" > upload_check.txt
+CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST $BASE_URL/upload -F "file=@upload_check.txt")
+if [[ "$CODE" == "200" || "$CODE" == "201" ]]; then
+    curl -s $BASE_URL/upload/upload_check.txt -o download_check.txt
+    if diff upload_check.txt download_check.txt > /dev/null; then
+        echo -e "✅ Upload & GET file -> ${GREEN}PASS${NC}"
+        ((PASS_COUNT++))
+    else
+        echo -e "❌ Upload & GET file -> ${RED}FAIL${NC} (content mismatch)"
+        ((FAIL_COUNT++))
+    fi
+else
+    echo -e "❌ Upload /upload -> ${RED}FAIL${NC} (got $CODE, expected 200/201)"
+    ((FAIL_COUNT++))
+fi
+
 # Summary
 echo
 echo "------------------------------------"


### PR DESCRIPTION
In this PR:

1. New tests were included in the bash script (unsuccessful delete and checking content for an uploaded file)

2. Removed allow_upload directive. It was confusing and unnecessary.

3. Constructing Response obj with 200 default code, only overwriting in case of error.

4. Successful delete now return 204 instead of generic 200

5. Dinamically setting "Allow" header with allowed_methods information from config parser