### PR TITLE
feat: implement HTTP redirection support

### DIFF
--- a/config/one-server.conf
+++ b/config/one-server.conf
@@ -12,7 +12,6 @@ server             {
         index index.htm a index.html;
         autoindex off;
         upload_path var/www/site1/uploads;
-        #allow_upload off;
     }
 
     location /images {
@@ -27,12 +26,21 @@ server             {
     location /upload {
         root /var/www/site1/uploads;
         upload_path var/www/site1/uploads;
-        allow_upload on;
         allowed_methods GET POST DELETE;
     }
 
     location /cgi-bin {
         root /var/www/site1/cgi;
         cgi_extension .py;
+    }
+
+    location /redirect {
+        return 301 /new;
+    }
+
+    location /new {
+        root /var/www/site1;
+        index redirect.html;
+        autoindex off;
     }
 }

--- a/include/LocationConfig.hpp
+++ b/include/LocationConfig.hpp
@@ -16,7 +16,6 @@ private:
     std::string return_target;
     std::string upload_dir;
     bool autoindex;
-    bool allow_upload;
     std::string cgi_extension;
 
 public:
@@ -35,7 +34,6 @@ public:
     const std::string &getReturnTarget() const { return return_target; };
     const std::string &getUploadDir() const { return upload_dir; };
     const bool &getAutoindex() const { return autoindex; };
-    const bool &getAllowUpload() const { return allow_upload; };
     const std::string &getCgiExtension() const { return cgi_extension; };
 
     //setters
@@ -46,9 +44,7 @@ public:
     void setRedirection(std::pair<int, std::string> set) { has_return = true; return_status = set.first; return_target = set.second;};
     void setUploadDir(std::string set) { upload_dir = set; };
     void setAutoindex(bool set) { autoindex = set; };
-    void setAllowUpload(bool set) { allow_upload = set; };
 	void setCgiExtension(std::string set) { cgi_extension = set; };
-
 };
 
 std::ostream &operator<<(std::ostream &os, const std::vector<LocationConfig> &obj);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -31,6 +31,7 @@ private:
     void handleGet(const Request &reqObj, const LocationConfig &loc);
     void handleDelete(const Request &reqObj);
     std::string getContentType(const std::string &path);
+    void handleRedirect(const LocationConfig &locConfig);
 
     // methods -- "POST"
     void handlePost(const Request &reqObj, LocationConfig loc);

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -102,7 +102,7 @@ ServerConfig ConfigParser::parseServerBlock(std::vector<std::string> lines) {
     if (servConfig.getPort() == -1) {
         errorMessage << "Missing port value in configuration file.\n";
         throw std::runtime_error(errorMessage.str());
-    } 
+    }
 
     return (servConfig);
 }
@@ -302,8 +302,6 @@ LocationConfig ConfigParser::parseLocationBlock(std::vector<std::string> lines)
             locConfig.setUploadDir(parseUploadDir(tokens));
         else if (!tokens.empty() && tokens[0] == "autoindex")
             locConfig.setAutoindex(parseAutoindex(tokens));
-        else if (!tokens.empty() && tokens[0] == "allow_upload")
-            locConfig.setAllowUpload(parseAllowUpload(tokens));
         else if (!tokens.empty() && tokens[0] == "cgi_extension")
         	locConfig.setCgiExtension(parseCgiExtension(tokens));
         else if (!tokens.empty() && tokens[0] != "}") {

--- a/src/LocationConfig.cpp
+++ b/src/LocationConfig.cpp
@@ -1,7 +1,7 @@
 #include "LocationConfig.hpp"
 #include <algorithm>
 
-LocationConfig::LocationConfig() : has_return(false), autoindex(false), allow_upload(false)
+LocationConfig::LocationConfig() : has_return(false), autoindex(false)
 {
     allowed_methods.push_back("GET");
     allowed_methods.push_back("POST");
@@ -16,7 +16,7 @@ std::ostream &operator<<(std::ostream &os, const std::vector<LocationConfig>& ob
         os << " -- Index: " << obj[i].getIndexFiles() << "\n";
         os << " -- Allowed methods: " << obj[i].getAllowedMethods() << "\n";
         os << " -- Redirection: " << obj[i].getReturnStatus() << " " << obj[i].getReturnTarget() << "\n";
-        os << " -- Allow upload: " << obj[i].getAllowUpload() << "\n";
+        //os << " -- Allow upload: " << obj[i].getAllowUpload() << "\n";
         os << " -- Upload dir: " << obj[i].getUploadDir() << "\n";
         os << " -- Autoindex: " << obj[i].getAutoindex() << "\n";
 		os << " -- CGI extension: " << obj[i].getCgiExtension() << "\n";

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -316,6 +316,11 @@ void Response::setCode(const int code)
         codeToMessage[200] = "OK";
         codeToMessage[201] = "Created";
         codeToMessage[204] = "No Content";
+        codeToMessage[301] = "Moved Permanently";
+        codeToMessage[302] = "Found";
+        codeToMessage[303] = "See Other";
+        codeToMessage[307] = "Temporary Redirect";
+        codeToMessage[308] = "Permanent Redirect";
         codeToMessage[400] = "Bad Request";
         codeToMessage[403] = "Forbidden";
         codeToMessage[404] = "Not Found";

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -402,16 +402,18 @@ std::string Response::buildResponse(const Request &reqObj, const LocationConfig 
         return (this->writeResponseString());
     }
 
-    else if (reqObj.isCgi()) {
-        this->handleCgi(reqObj, locConfig);
+    if (!locConfig.getReturnTarget().empty()) {
+        handleRedirect(locConfig);
+    } else if (reqObj.isCgi()) {
+        handleCgi(reqObj, locConfig);
     } else if (!reqObj.getMethod().compare("GET")) {
-        this->handleGet(reqObj, locConfig);
+        handleGet(reqObj, locConfig);
     } else if (!reqObj.getMethod().compare("POST")) {
-        this->handlePost(reqObj, locConfig);
+        handlePost(reqObj, locConfig);
     } else if (!reqObj.getMethod().compare("DELETE")) {
-        this->handleDelete(reqObj);
+        handleDelete(reqObj);
     } else
-        this->setPage(501, "Method not implemented", true);
+        setPage(501, "Method not implemented", true);
 
     //if (reqObj.findHeader(HEADER_CONNECTION))
     //    this->setHeader(HEADER_CONNECTION, *reqObj.findHeader(HEADER_CONNECTION));
@@ -430,9 +432,9 @@ std::string Response::buildResponse(const Request &reqObj, const LocationConfig 
     else // HTTP/1.0
         want_close = (connection != "keep-alive"); // default is close
 
-    this->setHeader("connection", want_close ? "close" : "keep-alive");
+    setHeader("connection", want_close ? "close" : "keep-alive");
 
-    return (this->writeResponseString());
+    return (writeResponseString());
 }
 
 void Response::handleCgi(const Request &reqObj, const LocationConfig &locConfig)
@@ -520,4 +522,20 @@ void Response::parseCgiResponse(const std::string &cgiOutput) {
     if (!findHeader("Content-Length")) {
         setHeader("Content-Length", int_to_string(b.size()));
     }
+}
+
+void Response::handleRedirect(const LocationConfig &locConfig)
+{
+    int statusCode = locConfig.getReturnStatus();
+    statusCode_ = statusCode;
+    std::string newLocation = locConfig.getReturnTarget();
+    setCode(statusCode);
+    setHeader("Location", newLocation);
+
+    body_ =
+        "<html><head><title>" + std::to_string(statusCode) + " " + statusMessage_ + "</title></head>"
+        "<body style='font-family:sans-serif;text-align:center;margin-top:100px;'>"
+        "<h1>" + std::to_string(statusCode) + " " + statusMessage_ + "</h1>"
+        "<p>Resource has moved to <a href=\"" +
+        newLocation + "\">" + newLocation + "</a>.</p></body></html>";
 }

--- a/var/www/site1/redirect.html
+++ b/var/www/site1/redirect.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome to /new</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 100px;
+            background-color: #f5f5f5;
+        }
+
+        h1 {
+            color: #2c3e50;
+        }
+
+        p {
+            color: #34495e;
+            font-size: 18px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>🎉 Welcome to the new location!</h1>
+    <p>Hi! You’ve been successfully redirected to <strong>/new</strong>.</p>
+    <p>Everything is working fine here.</p>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds support for HTTP redirection, including configuration, status codes, and response handling.

Changes include:
- Updated config with a `/redirect` location pointing to `/new`.
- Added `/new` location with its own instructions.
- Implemented support for redirect status codes 301, 302, 303, 307, and 308.
- Updated` buildResponse() `to handle redirection before CGI and method checks.
- Removed unused `allowUpload` logic from config.
- Added an HTML page for `/new` that displays a redirect success message.

This enables proper HTTP redirection handling in the server while keeping the 
codebase cleaner and more maintainable.