### PR TITLE
Refactor/enhance configparser

### DIFF
--- a/include/ConfigParser.hpp
+++ b/include/ConfigParser.hpp
@@ -17,7 +17,7 @@ private:
     std::ostringstream errorMessage;
     std::string fileName;
     size_t lineNum;
-    
+
     std::vector<std::string> collectBlock(std::vector<std::string> lines, size_t i);
     ServerConfig parseServerBlock(std::vector<std::string> lines);
     LocationConfig parseLocationBlock(std::vector<std::string> lines);
@@ -42,7 +42,5 @@ public:
     Config  parseConfigFile(const std::string &filename);
 };
 
-std::string trimComment(std::string line);
-std::string trimWhitespace(std::string line);
-std::string trimLine(std::string line);
+std::string cleanLine(std::string line);
 std::vector<std::string> tokenize(const std::string line);

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -2,6 +2,16 @@
 #include "Config.hpp"
 #include "Utils.hpp"
 
+inline void throwConfigError(const std::string &file, int line, const std::string &msg)
+{
+    throw std::runtime_error(file + ":" + util::intToString(line) + "  " + msg);
+}
+
+inline bool isDirective(const std::vector<std::string> &tokens, const std::string &name)
+{
+    return !tokens.empty() && tokens[0] == name;
+}
+
 Config ConfigParser::parseConfigFile(const std::string &filename) {
     Config config;
     fileName = filename;
@@ -27,10 +37,8 @@ Config ConfigParser::parseConfigFile(const std::string &filename) {
         tokens = tokenize(line);
         if (!tokens.empty()) {
             if (tokens[0] == "server") {
-                if (tokens[1] != "{") {
-                    errorMessage << fileName << ":" << i + 1 << "Expected '{' after 'server'";
-                    throw std::runtime_error(errorMessage.str());
-                }
+                if (tokens[1] != "{")
+                    throwConfigError(fileName, i + 1, "Expected '{' after 'server'");
                 lineNum = i + 1;
                 std::vector<std::string> serverLines = collectBlock(lines, i);
                 ServerConfig server = parseServerBlock(serverLines);
@@ -74,15 +82,15 @@ ServerConfig ConfigParser::parseServerBlock(std::vector<std::string> lines) {
         std::string line = cleanLine(lines[i]);
         lineNum ++;
         tokens = tokenize(line);
-        if (!tokens.empty() && tokens[0] == "host" && servConfig.getHost().empty())
+        if (isDirective(tokens, "host") && servConfig.getHost().empty())
             servConfig.setHost(parseHost(tokens));
-        else if (!tokens.empty() && tokens[0] == "listen" && servConfig.getPort() == -1)
+        else if (isDirective(tokens, "listen") && servConfig.getPort() == -1)
             servConfig.setPort(parsePort(tokens));
-        else if (!tokens.empty() && tokens[0] == "error_page")
+        else if (isDirective(tokens, "error_page"))
             servConfig.setErrorPagesConfig(parseErrorPageLine(tokens));
-        else if (!tokens.empty() && tokens[0] == "client_max_body_size" && servConfig.getMaxBodySize() == -1)
+        else if (isDirective(tokens, "client_max_body_size") && servConfig.getMaxBodySize() == -1)
             servConfig.setMaxBodySize(parseMaxBodySize(tokens));
-        else if (!tokens.empty() && tokens[0] == "location")
+        else if (isDirective(tokens, "location"))
         {
             lineNum --;
             std::vector<std::string> locationLines = collectBlock(lines, i);
@@ -92,18 +100,13 @@ ServerConfig ConfigParser::parseServerBlock(std::vector<std::string> lines) {
             lineNum ++;
         }
         else if (!tokens.empty() && tokens[0] != "}")
-        {
-            errorMessage << fileName << ":" << lineNum << "   \"" << tokens[0] << "\" directive is not allowed here\n";
-            throw std::runtime_error(errorMessage.str());
-        }
+            throwConfigError(fileName, lineNum, "   \"" + tokens[0] + "\" directive is not allowed here\n");
     }
 
     if (servConfig.getHost().empty())
         servConfig.setHost("0.0.0.0");
-    if (servConfig.getPort() == -1) {
-        errorMessage << "Missing port value in configuration file.\n";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (servConfig.getPort() == -1)
+        throwConfigError(fileName, lineNum, "Missing port value in configuration file.\n");
 
     return (servConfig);
 }
@@ -111,14 +114,11 @@ ServerConfig ConfigParser::parseServerBlock(std::vector<std::string> lines) {
 std::string ConfigParser::parseHost(const std::vector<std::string> &tokens)
 {
     std::vector<std::string> octets;
-    if (tokens.size() < 2) {
-        errorMessage << fileName << ":" << lineNum << "  Missing host value in configuration file.\n";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (tokens.size() < 2)
+        throwConfigError(fileName, lineNum, "  Missing host value in configuration file.\n");
 
     std::string host = tokens[1];
 
-    //splits address into octets
     for (int i = 0; i < 4; i++) {
         size_t pos = host.find('.');
         if (pos == std::string::npos)
@@ -127,72 +127,49 @@ std::string ConfigParser::parseHost(const std::vector<std::string> &tokens)
         host = host.substr(pos + 1);
     }
     octets.push_back(host);
-    if (octets.size() != 4) {
-        errorMessage << fileName << ":" << lineNum << "  Invalid host IP address in configuration file\n";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (octets.size() != 4)
+        throwConfigError(fileName, lineNum, "  Invalid host IP address in configuration file\n");
+
     for (int i = 0; i < 4; i++) {
-        //checks if octets empty, which would catch an error if ip address is missing an octet
-        if (octets[i].empty()) {
-            errorMessage << fileName << ":" << lineNum << "  Host address incomplete in configuration file\n";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (octets[i].empty())
+            throwConfigError(fileName, lineNum, "  Host address incomplete in configuration file\n");
 
-        //rejects leading 0 ("0" is ok, but "00" ou "01" is not!)
-        if (octets[i][0] == '0' && octets[i].length() > 1) {
-            errorMessage << fileName << ":" << lineNum << "  Host address contains leading zeros in configuration file\n";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (octets[i][0] == '0' && octets[i].length() > 1)
+            throwConfigError(fileName, lineNum, "  Host address contains leading zeros in configuration file\n");
 
-
-        //checks if the octet is purely digits. whitespace isnt a problem here, octets[i] is already a token
         for (std::string::const_iterator it = octets[i].begin(); it != octets[i].end(); ++it) {
-            if (!isdigit(*it)) {
-                errorMessage << fileName << ":" << lineNum << "  Host address must include digits only\n";
-                throw std::runtime_error(errorMessage.str());
-            }
+            if (!isdigit(*it))
+                throwConfigError(fileName, lineNum, "  Host address must include digits only\n");
         }
 
-        //converts them to int in order to check the range
         int num = std::atoi(octets[i].c_str());
-        if ((num == 0 && octets[i] != "0") || num < 0 || num > 255) {
-            errorMessage << fileName << ":" << lineNum << "  Invalid host IP address in configuration file\n";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if ((num == 0 && octets[i] != "0") || num < 0 || num > 255)
+            throwConfigError(fileName, lineNum, "  Invalid host IP address in configuration file\n");
     }
     return (tokens[1]);
 }
 
 int ConfigParser::parsePort(const std::vector<std::string> &tokens)
 {
-    if (tokens.size() < 2) {
-        errorMessage << fileName + ":" << lineNum << "  Missing port value in configuration file.";
-		throw std::runtime_error(errorMessage.str());
-    }
+    if (tokens.size() < 2)
+        throwConfigError(fileName, lineNum, "  Missing port value in configuration file.");
 
-    if (tokens.size() > 2) {
-        errorMessage << fileName + ":" << lineNum << "  Port value contains unexpected spaces or extra tokens";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (tokens.size() > 2)
+        throwConfigError(fileName, lineNum, "  Port value contains unexpected spaces or extra tokens");
 
     for (std::string::const_iterator it = tokens[1].begin(); it != tokens[1].end(); ++it)
     {
         if (!isdigit(*it)) {
-            errorMessage << fileName + ":" << lineNum << "  Port must include digits only";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  Port must include digits only");
         }
     }
 
     int portInt = std::atoi(tokens[1].c_str());
-    if (portInt == 0 && tokens[1] != "0") {
-        errorMessage << fileName + ":" << lineNum << "  Invalid port number '" << tokens[1] + "'";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (portInt == 0 && tokens[1] != "0")
+        throwConfigError(fileName, lineNum, "  Invalid port number '" + tokens[1] + "'");
 
-    if (portInt < 1 || portInt > 65535) {
-        errorMessage << fileName << ":" << lineNum << "  Port number '" << tokens[1] << "' out of range";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (portInt < 1 || portInt > 65535)
+        throwConfigError(fileName, lineNum, "  Port number '" + tokens[1] + "' out of range");
 
     return (portInt);
 }
@@ -200,31 +177,24 @@ int ConfigParser::parsePort(const std::vector<std::string> &tokens)
 std::pair<int, std::string> ConfigParser::parseErrorPageLine(const std::vector<std::string> &tokens)
 {
     std::pair<int, std::string> entry;
-    if (tokens.size() < 3) {
-        errorMessage << fileName << ":" << lineNum << "  Unable to parse error_page, missing value";
-        throw std::runtime_error(errorMessage.str());
-    }
+    if (tokens.size() < 3)
+        throwConfigError(fileName, lineNum, "  Unable to parse error_page, missing value");
 
     if (tokens.size() > 3)
-    {
-        errorMessage << fileName << ":" << lineNum << "  error_page contains unexpected spaces or extra tokens";
-        throw std::runtime_error(errorMessage.str());
-    }
+        throwConfigError(fileName, lineNum, "  error_page contains unexpected spaces or extra tokens");
 
     for (std::string::const_iterator it = tokens[1].begin(); it != tokens[1].end(); ++it)
     {
-        if (!isdigit(*it)) {
-            errorMessage << fileName << ":" << lineNum << "  Error code must include digits only";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (!isdigit(*it))
+            throwConfigError(fileName, lineNum, "  Error code must include digits only");
     }
 
     int key = std::atoi(tokens[1].c_str());
     if (key == 0 && tokens[1] != "0")
-		throw std::runtime_error(std::string("Invalid error code '") + tokens[1] + "'");
+        throwConfigError(fileName, lineNum, "Invalid error code '" + tokens[1] + "'");
 
     if (key < 300 || key > 599)
-        throw std::runtime_error(std::string("Invalid error code '") + tokens[1] + "': not a valid HTTP error code");
+        throwConfigError(fileName, lineNum,"Invalid error code '" + tokens[1] + "': not a valid HTTP error code");
 
     entry = std::make_pair(key, tokens[2]);
     return (entry);
@@ -233,15 +203,11 @@ std::pair<int, std::string> ConfigParser::parseErrorPageLine(const std::vector<s
 size_t ConfigParser::parseMaxBodySize(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2)
-    {
-        errorMessage << fileName << ":" << lineNum << "  Error: Missing argument for client_max_body_size";
-        throw std::runtime_error(errorMessage.str());
-    }
+        throwConfigError(fileName, lineNum, "  Error: Missing argument for client_max_body_size");
 
     std::string value = tokens[1];
     size_t multiplier = 1;
 
-    // Use operator[] instead of .back()
     char unit = value[value.size() - 1];
 
     if (!std::isdigit(unit))
@@ -261,22 +227,17 @@ size_t ConfigParser::parseMaxBodySize(const std::vector<std::string> &tokens)
                 multiplier = 1024 * 1024 * 1024;
                 break;
             default:
-				errorMessage << fileName << ":" << lineNum << "  Unknown size unit in client_max_body_size";
-                throw std::runtime_error(errorMessage.str());
+				throwConfigError(fileName, lineNum, "  Unknown size unit in client_max_body_size");
         }
 
-        // Use resize() instead of pop_back()
         value.resize(value.size() - 1);
     }
 
     int number = std::atoi(value.c_str());
     if (number <= 0)
-    {
-        errorMessage << fileName << ":" << lineNum << "  Invalid numeric value for client_max_body_size";
-        throw std::runtime_error(errorMessage.str());
-    }
+        throwConfigError(fileName, lineNum, "  Invalid numeric value for client_max_body_size");
 
-    return static_cast<size_t>(number) * multiplier;
+    return (static_cast<size_t>(number) * multiplier);
 }
 
 LocationConfig ConfigParser::parseLocationBlock(std::vector<std::string> lines)
@@ -289,25 +250,24 @@ LocationConfig ConfigParser::parseLocationBlock(std::vector<std::string> lines)
         lineNum ++;
         lines[i] = cleanLine(lines[i]);
         tokens = tokenize(lines[i]);
-        if (!tokens.empty() && tokens[0] == "location")
+        if (isDirective(tokens, "location"))
             locConfig.setUri(parsePath(tokens));
-        else if (!tokens.empty() && tokens[0] == "root")
+        else if (isDirective(tokens, "root"))
             locConfig.setRoot(parseRoot(tokens));
-        else if (!tokens.empty() && tokens[0] == "index")
+        else if (isDirective(tokens, "index"))
             locConfig.setIndex(parseIndex(tokens));
-        else if (!tokens.empty() && tokens[0] == "allowed_methods")
+        else if (isDirective(tokens, "allowed_methods"))
             locConfig.setAllowedMethods(parseAllowedMethods(tokens));
-        else if (!tokens.empty() && tokens[0] == "return")
+        else if (isDirective(tokens, "return"))
             locConfig.setRedirection(parseRedirection(tokens));
-        else if (!tokens.empty() && tokens[0] == "upload_path")
+        else if (isDirective(tokens, "upload_path"))
             locConfig.setUploadDir(parseUploadDir(tokens));
-        else if (!tokens.empty() && tokens[0] == "autoindex")
+        else if (isDirective(tokens, "autoindex"))
             locConfig.setAutoindex(parseAutoindex(tokens));
-        else if (!tokens.empty() && tokens[0] == "cgi_extension")
+        else if (isDirective(tokens, "cgi_extension"))
         	locConfig.setCgiExtension(parseCgiExtension(tokens));
         else if (!tokens.empty() && tokens[0] != "}") {
-            errorMessage << fileName << ":" << lineNum << "   \"" << tokens[0] << "\" directive is not allowed here\n";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "   \"" + tokens[0] + "\" directive is not allowed here\n");
         }
     }
     return (locConfig);
@@ -316,52 +276,41 @@ LocationConfig ConfigParser::parseLocationBlock(std::vector<std::string> lines)
 std::string ConfigParser::parsePath(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2) {
-        errorMessage << fileName << ":" << lineNum << "  Missing path value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Missing path value in configuration file.");
     }
 
     if (tokens[0] == "location") {
-        if (tokens[1][0] != '/') {
-            errorMessage << fileName << ":" << lineNum << "  Path missing starting slash";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (tokens[1][0] != '/')
+            throwConfigError(fileName, lineNum, "  Path missing starting slash");
 
-        if (tokens.size() > 3 && !tokens[2].empty()) {
-            errorMessage << fileName << ":" << lineNum << "  Path contains unexpected spaces or extra tokens";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (tokens.size() > 3 && !tokens[2].empty())
+            throwConfigError(fileName, lineNum, "  Path contains unexpected spaces or extra tokens");
 
-        if (!util::isValidPath(tokens[1])) {
-            errorMessage << fileName << ":" << lineNum << "  Path contains illegal characters";
-            throw std::runtime_error(errorMessage.str());
-        }
+        if (!util::isValidPath(tokens[1]))
+            throwConfigError(fileName, lineNum, "  Path contains illegal characters");
         return (util::normalizePath(tokens[1]));
     }
 
-    errorMessage << fileName << ":" << lineNum << "  Incorrect syntax for location path.";
-    throw (std::runtime_error(errorMessage.str()));
+    throwConfigError(fileName, lineNum, "  Incorrect syntax for location path.");
+    return ("");
 }
 
 std::string ConfigParser::parseRoot(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2) {
-		errorMessage << fileName << ":" << lineNum << "  Missing root value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+		throwConfigError(fileName, lineNum, "  Missing root value in configuration file.");
     }
 
     if (tokens.size() > 2) {
-        errorMessage << fileName << ":" << lineNum << "  Root path contains unexpected spaces or extra tokens";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Root path contains unexpected spaces or extra tokens");
     }
 
     if (tokens[1][0] != '/'){
-        errorMessage << fileName << ":" << lineNum << "  Root path must start with '/'";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Root path must start with '/'");
     }
 
     if (!util::isValidPath(tokens[1])){
-        errorMessage << fileName << ":" << lineNum << "  Root path contains illegal characters";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Root path contains illegal characters");
     }
 
     return (tokens[1]);
@@ -370,21 +319,18 @@ std::string ConfigParser::parseRoot(const std::vector<std::string> &tokens)
 std::vector<std::string> ConfigParser::parseIndex(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2) {
-        errorMessage << fileName << ":" << lineNum << "  Missing index value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Missing index value in configuration file.");
     }
 
     std::vector<std::string> ret;
 
     for (size_t i = 1; i < tokens.size(); i++) {
         if (tokens[i].empty()) {
-            errorMessage << fileName << ":" << lineNum << "  Index value cannot be empty";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  Index value cannot be empty");
         }
 
         if (!util::isValidPath(tokens[i])){
-            errorMessage << fileName << ":" << lineNum << "  Index value contains illegal characters: " << tokens[i];
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  Index value contains illegal characters: " + tokens[i]);
         }
 
         ret.push_back(tokens[i]);
@@ -397,8 +343,7 @@ std::vector<std::string> ConfigParser::parseAllowedMethods(const std::vector<std
     std::vector<std::string> ret;
 
     if (tokens.size() < 2){
-        errorMessage << fileName << ":" << lineNum << "  Missing allowed_methods value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Missing allowed_methods value in configuration file.");
     }
 
     std::set<std::string> seen;
@@ -407,13 +352,11 @@ std::vector<std::string> ConfigParser::parseAllowedMethods(const std::vector<std
     {
         const std::string &method = tokens[i];
         if (method.empty()){
-            errorMessage << fileName << ":" << lineNum << "  allowed_methods: empty method value is not allowed";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  allowed_methods: empty method value is not allowed");
         }
 
         if (method != "GET" && method != "POST" && method != "DELETE"){
-            errorMessage << fileName << ":" << lineNum << "  allowed_methods: unsupported HTTP method '" << method << "'";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  allowed_methods: unsupported HTTP method '" + method + "'");
         }
         if (seen.find(method) == seen.end()) {
             ret.push_back(method);
@@ -428,8 +371,7 @@ std::pair<int, std::string> ConfigParser::parseRedirection(const std::vector<std
 
     std::pair<int, std::string> entry;
     if (tokens.size() < 3) {
-        errorMessage << fileName << ":" << lineNum << "  Unable to parse return, missing value";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Unable to parse return, missing value");
     }
 
     if (tokens[2] == "\"\"" || tokens[2].empty())
@@ -437,24 +379,22 @@ std::pair<int, std::string> ConfigParser::parseRedirection(const std::vector<std
 
     if (tokens.size() > 3)
     {
-        errorMessage << fileName << ":" << lineNum << "  return contains unexpected spaces or extra tokens";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  return contains unexpected spaces or extra tokens");
     }
 
     for (std::string::const_iterator it = tokens[1].begin(); it != tokens[1].end(); ++it)
     {
         if (!isdigit(*it)) {
-            errorMessage << fileName << ":" << lineNum << "  Redirection code must include digits only";
-            throw std::runtime_error(errorMessage.str());
+            throwConfigError(fileName, lineNum, "  Redirection code must include digits only");
         }
     }
 
     int key = std::atoi(tokens[1].c_str());
     if (key == 0 && tokens[1] != "0")
-		throw std::runtime_error(std::string("Invalid redirection code '") + tokens[1] + "'");
+		throwConfigError(fileName, lineNum, "Invalid redirection code '" + tokens[1] + "'");
 
     if ((key < 301 || key > 302) && (key < 307 || key > 308))
-        throw std::runtime_error(std::string("Invalid redirection code '") + tokens[1] + "': not a valid HTTP redirection code");
+        throwConfigError(fileName, lineNum, "Invalid redirection code '" + tokens[1] + "': not a valid HTTP redirection code");
 
     entry = std::make_pair(key, tokens[2]);
     return (entry);
@@ -463,18 +403,11 @@ std::pair<int, std::string> ConfigParser::parseRedirection(const std::vector<std
 std::string ConfigParser::parseUploadDir(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2) {
-        errorMessage << fileName << ":" << lineNum << "  Missing upload_path value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Missing upload_path value in configuration file.");
     }
 
-    // if (tokens[1][0] != '/') {
-    //     errorMessage << fileName << ":" << lineNum << "  Missing leading slash in upload_path value in configuration file.";
-    //     throw std::runtime_error(errorMessage.str());
-    // }
-
     if (tokens[1] == "/") {
-        errorMessage << fileName << ":" << lineNum << "  Upload path cannot be root '/'";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Upload path cannot be root '/'");
     }
 
     return (tokens[1]);
@@ -483,13 +416,11 @@ std::string ConfigParser::parseUploadDir(const std::vector<std::string> &tokens)
 bool ConfigParser::parseAutoindex(const std::vector<std::string> &tokens)
 {
     if (tokens.size() < 2) {
-        errorMessage << fileName << ":" << lineNum << "  Missing autoindex value in configuration file.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Missing autoindex value in configuration file.");
     }
 
     if (tokens.size() > 2) {
-        errorMessage << fileName << ":" << lineNum << "  Autoindex contains unexpected extra tokens.";
-        throw std::runtime_error(errorMessage.str());
+        throwConfigError(fileName, lineNum, "  Autoindex contains unexpected extra tokens.");
     }
 
     if (tokens[1] == "on")
@@ -497,26 +428,26 @@ bool ConfigParser::parseAutoindex(const std::vector<std::string> &tokens)
     if (tokens[1] == "off")
         return (false);
 
-    errorMessage << fileName << ":" << lineNum << "  Incorrect syntax for autoindex directive.";
-    throw std::runtime_error(errorMessage.str());
+    throwConfigError(fileName, lineNum, "  Incorrect syntax for autoindex directive.");
+    return (false);
 }
 
 std::string ConfigParser::parseCgiExtension(const std::vector<std::string> &tokens)
 {
 	if (tokens.size() != 2) {
-		throw std::runtime_error("Error: Exactly one CGI extension must be specified in the configuration file.");
+		throwConfigError(fileName, lineNum, "Error: Exactly one CGI extension must be specified in the configuration file.");
 	}
 
 	const std::string &extension = tokens[1];
 
 	if (extension.empty()) {
-		throw std::runtime_error("Error: Empty CGI extension is not allowed.");
+		throwConfigError(fileName, lineNum, "Error: Empty CGI extension is not allowed.");
 	}
 	if (extension[0] != '.') {
-        throw std::runtime_error("Error: CGI extension must start with a '.' character.");
+        throwConfigError(fileName, lineNum, "Error: CGI extension must start with a '.' character.");
     }
 	if (!util::isValidPath(extension)) {
-		throw std::runtime_error("Error: Invalid CGI extension '" + extension + "'.");
+		throwConfigError(fileName, lineNum, "Error: Invalid CGI extension '" + extension + "'.");
 	}
 	return extension;
 }

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -18,12 +18,12 @@ Config ConfigParser::parseConfigFile(const std::string &filename) {
     std::vector<std::string> lines;
     std::string line;
     while (std::getline(file, line)) {
-        lines.push_back(trimLine(line));
+        lines.push_back(cleanLine(line));
     }
 
     std::vector<std::string> tokens;
     for (size_t i = 0; i < lines.size(); i++) {
-        line = trimLine(lines[i]);
+        line = cleanLine(lines[i]);
         tokens = tokenize(line);
         if (!tokens.empty()) {
             if (tokens[0] == "server") {
@@ -71,7 +71,7 @@ ServerConfig ConfigParser::parseServerBlock(std::vector<std::string> lines) {
     std::vector<std::string> tokens;
 
     for (size_t i = 1; i < lines.size(); i++) {
-        std::string line = trimLine(lines[i]);
+        std::string line = cleanLine(lines[i]);
         lineNum ++;
         tokens = tokenize(line);
         if (!tokens.empty() && tokens[0] == "host" && servConfig.getHost().empty())
@@ -287,7 +287,7 @@ LocationConfig ConfigParser::parseLocationBlock(std::vector<std::string> lines)
     for (size_t i = 0; i < lines.size(); i++)
     {
         lineNum ++;
-        lines[i] = trimLine(lines[i]);
+        lines[i] = cleanLine(lines[i]);
         tokens = tokenize(lines[i]);
         if (!tokens.empty() && tokens[0] == "location")
             locConfig.setUri(parsePath(tokens));
@@ -521,36 +521,22 @@ std::string ConfigParser::parseCgiExtension(const std::vector<std::string> &toke
 	return extension;
 }
 
-std::string trimComment(std::string line) {
+std::string cleanLine(std::string line)
+{
     if (line.empty())
-        return (line);
+        return line;
     size_t pos = line.find("#");
-    if (pos != std::string::npos) {
+    if (pos != std::string::npos)
         line = line.substr(0, pos);
-    }
-    return (line);
-}
 
-std::string trimWhitespace(std::string line) {
-    if (line.empty())
-        return (line);
-    while (!line.empty() && std::isspace(line[0])) {
+    while (!line.empty() && std::isspace(line[0]))
         line = line.substr(1);
-    }
-    while (!line.empty() && std::isspace(line[line.length() - 1])) {
-        line.resize(line.length() - 1);
-    }
-    return (line);
-}
+    while (!line.empty() && std::isspace(line[line.size() - 1]))
+        line.resize(line.size() - 1);
 
-std::string trimLine(std::string line) {
-    if (line.empty())
-        return (line);
-    line = trimComment(line);
-    line = trimWhitespace(line);
-   if (!line.empty() && line[line.length() - 1] == ';')
-        line.resize(line.length() - 1);
-    return (line);
+    if (!line.empty() && line[line.size() - 1] == ';')
+        line.resize(line.size() - 1);
+    return line;
 }
 
 std::vector<std::string> tokenize(const std::string line) {


### PR DESCRIPTION
On this PR:

- Renamed trim functions to cleanLine in order to simplify implementation
- Introduced two inline functions: isDirective and throwConfigError, also to simplify implementation.

No new features were added.