### PR TITLE
Refactor/enhance response

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -35,6 +35,9 @@ private:
     void readFileIntoBody(const std::string &fileName);
     std::string generateDefaultPage(const int code, const std::string &message, bool error) const;
 
+    void handleCgi(const Request &reqObj, const LocationConfig &locConfig);
+    void parseCgiResponse(const std::string &cgiOutput);
+
 public:
     Response();
     Response(std::map<int, std::string> error_pages_config);
@@ -49,9 +52,7 @@ public:
 
     void setFullPath(const std::string &reqPath);
     void setCode(const int code);
-    void setPage(const  int code, const std::string &message, bool error);
-	void handleCgi(const Request &reqObj, const LocationConfig &locConfig);
-	void parseCgiResponse(const std::string &cgiOutput);
+    void setPage(const int code, const std::string &message, bool error);
 };
 
 std::ostream &operator<<(std::ostream &out, const Response &obj);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -23,7 +23,7 @@ private:
 
     void parseMultipartBody(const Request &obj);
     void generateAutoIndex(const LocationConfig &loc);
-    void handleGet(const Request &reqObj, const LocationConfig &loc);
+    void handleGet(const LocationConfig &loc);
     void handleDelete(const Request &reqObj);
     std::string getContentType(const std::string &path);
     void handleRedirect(const LocationConfig &locConfig);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -14,19 +14,13 @@ class Response : public HttpMessage
 private:
     static const int MAX_URI_LENGTH = 8192;
 
-    // HTTP status info
     int statusCode_;
     std::string statusMessage_;
-
-    // File info
     std::string fullPath_;
     std::string filename_;
     std::string contentType_;
-
-    // Config info
     std::map<int, std::string> error_pages_config;
 
-    // methods
     void parseMultipartBody(const Request &obj);
     void generateAutoIndex(const LocationConfig &loc);
     void handleGet(const Request &reqObj, const LocationConfig &loc);
@@ -34,14 +28,10 @@ private:
     std::string getContentType(const std::string &path);
     void handleRedirect(const LocationConfig &locConfig);
 
-    // methods -- "POST"
     void handlePost(const Request &reqObj, LocationConfig loc);
     void createUploadDir(const std::string &uploadFullPath);
     void uploadFile(const std::string &uploadFullPath);
 
-    // methods -- general
-
-    // methods --- utils
     void readFileIntoBody(const std::string &fileName);
     std::string generateDefaultPage(const int code, const std::string &message, bool error) const;
 
@@ -50,16 +40,13 @@ public:
     Response(std::map<int, std::string> error_pages_config);
     Response(std::map<int, std::string> error_pages_config, int code, const std::string &message, bool error);
 
-    // methods
     std::string writeResponseString() const;
     std::string buildResponse(const Request &reqObj, const LocationConfig &Config);
 
-    // getter
     int getCode() const { return statusCode_; }
     const std::string getStatusMessage() const { return statusMessage_; }
     const std::string getFullPath() const { return fullPath_; }
 
-    //setter
     void setFullPath(const std::string &reqPath);
     void setCode(const int code);
     void setPage(const  int code, const std::string &message, bool error);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
 #include <string>
+#include <sys/stat.h>
+#include <vector>
 
 namespace util {
     std::string normalizePath(const std::string &rawPath);
     bool isValidPathChar(char c);
     bool isValidPath(const std::string &path);
     std::string intToString(int value);
+    bool fileExists(const std::string &path, struct ::stat &st);
+    std::string wrapHtml(const std::string &title, const std::string &body);
+    std::string generateAutoIndexHtml(const std::string &uri, const std::vector<std::string> &entries);
 }

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -20,6 +20,20 @@ static const char *HEADER_CONTENT_LENGTH = "content-length";
 static const char *HEADER_CONNECTION = "connection";
 static const char *MIME_HTML = "text/html";
 
+static const std::pair<const char *, const char *> mimeArray[] = {
+    std::pair<const char *, const char *>(".html", "text/html"),
+    std::pair<const char *, const char *>(".htm", "text/html"),
+    std::pair<const char *, const char *>(".css", "text/css"),
+    std::pair<const char *, const char *>(".js", "application/javascript"),
+    std::pair<const char *, const char *>(".png", "image/png"),
+    std::pair<const char *, const char *>(".jpg", "image/jpeg"),
+    std::pair<const char *, const char *>(".jpeg", "image/jpeg"),
+    std::pair<const char *, const char *>(".gif", "image/gif"),
+    std::pair<const char *, const char *>(".txt", "text/plain"),
+    std::pair<const char *, const char *>(".pdf", "application/pdf"),
+    std::pair<const char *, const char *>(".json", "application/json"),
+    std::pair<const char *, const char *>(".svg", "image/svg+xml")};
+
 Response::Response() : fullPath_(".") {}
 
 Response::Response(std::map<int, std::string> error_pages)
@@ -128,28 +142,22 @@ void Response::generateAutoIndex(const LocationConfig& loc) {
 
     html << "</ul>\n</body>\n</html>\n";
     closedir(dir);
-    body_ = html.str();
-    return;
+    body_ = util::generateAutoIndexHtml(uri, entries);
+}
+
+static std::map<std::string, std::string> initMime()
+{
+    std::map<std::string, std::string> m;
+    size_t len = sizeof(mimeArray) / sizeof(mimeArray[0]);
+    for (size_t i = 0; i < len; ++i)
+        m[mimeArray[i].first] = mimeArray[i].second;
+    return m;
 }
 
 std::string Response::getContentType(const std::string &path)
 {
-    static std::map<std::string, std::string> mime;
-    if (mime.empty())
-    {
-        mime[".html"] = "text/html";
-        mime[".htm"] = "text/html";
-        mime[".css"] = "text/css";
-        mime[".js"] = "application/javascript";
-        mime[".png"] = "image/png";
-        mime[".jpg"] = "image/jpeg";
-        mime[".jpeg"] = "image/jpeg";
-        mime[".gif"] = "image/gif";
-        mime[".txt"] = "text/plain";
-        mime[".pdf"] = "application/pdf";
-        mime[".json"] = "application/json";
-        mime[".svg"] = "image/svg+xml";
-    }
+    static std::map<std::string, std::string> mime = initMime();
+
     size_t dot = path.rfind('.');
     if (dot != std::string::npos) {
         std::string ext = path.substr(dot);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 #include <sstream>
 #include <vector>
-
+#include <cerrno>
 
 namespace util {
     std::string normalizePath(const std::string &rawPath)

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,8 +1,12 @@
 
 #include "Utils.hpp"
+#include "HttpException.hpp"
 
+#include <string>
+#include <sys/stat.h>
 #include <sstream>
 #include <vector>
+
 
 namespace util {
     std::string normalizePath(const std::string &rawPath)
@@ -56,5 +60,44 @@ namespace util {
         std::ostringstream oss;
         oss << value;
         return oss.str();
+    }
+
+    bool fileExists(const std::string &path, struct ::stat &st)
+    {
+        if (::stat(path.c_str(), &st) == 0)
+            return true;
+        if (errno == ENOENT)
+            throw HttpException(404, "File does not exist", true);
+        if (errno == EACCES)
+            throw HttpException(403, "Access denied", true);
+        throw HttpException(500, "Internal server error while accessing file", true);
+    }
+
+    std::string wrapHtml(const std::string &title, const std::string &body)
+    {
+        std::ostringstream html;
+        html << "<!DOCTYPE html>\n<html>\n<head>\n"
+             << "<meta charset=\"UTF-8\">\n<title>" << title << "</title>\n"
+             << "</head>\n<body>\n"
+             << body
+             << "\n</body>\n</html>";
+        return html.str();
+    }
+
+    std::string generateAutoIndexHtml(const std::string &uri, const std::vector<std::string> &entries)
+    {
+        std::ostringstream body;
+        body << "<h1>Index of " << uri << "</h1>\n<ul>\n";
+
+        for (std::vector<std::string>::const_iterator it = entries.begin(); it != entries.end(); ++it)
+        {
+            body << "<li><a href=\"" << uri;
+            if (uri[uri.size() - 1] != '/')
+                body << "/";
+            body << *it << "\">" << *it << "</a></li>\n";
+        }
+        body << "</ul>\n";
+
+        return wrapHtml("Index of " + uri, body.str());
     }
 }


### PR DESCRIPTION
On this PR:

- Reorganized CGI methods com Response class from public to private, removing unecessary exposure
- Simplified getContentType by providing a constant array of MIMEs
- Created fileExists in Utils.cpp to remove repetitive lines in Response.cpp
- Created wrapHtml and generateAutoIndexHtml in Utils.cpp to promote cleaner code